### PR TITLE
Stop accounts breaking without mailing

### DIFF
--- a/resources/view/account/account.html.twig
+++ b/resources/view/account/account.html.twig
@@ -29,7 +29,9 @@
 	{% set address = deliveryAddress %}
 	{% include 'Message:Mothership:Commerce::order:detail:address:detail' %}
 {% endif %}
+{% if subscribed is defined %}
 <p>
-	<li>Send me E-Mail updates? {{ subscribed }} </li>
+	Send me E-Mail updates? {{ subscribed }}
 </p>
+{% endif %}
 {% endblock %}

--- a/src/Controller/Account/Account.php
+++ b/src/Controller/Account/Account.php
@@ -18,16 +18,21 @@ class Account extends Controller
 	public function index()
 	{
 		$user            = $this->get('user.current');
-		$subscribed      = $this->get('mailing.subscription.loader')->getByUser($user)->isSubscribed();
 		$billingAddress  = $this->get('user.address.loader')->getByUserAndType($user, 'billing');
 		$deliveryAddress = $this->get('user.address.loader')->getByUserAndType($user, 'delivery');
 
-		return $this->render('Message:Mothership:User::account:account', array(
+		$details = [
 			'user'            => $user,
-			'subscribed'      => $subscribed,
 			'billingAddress'  => $billingAddress,
 			'deliveryAddress' => $deliveryAddress,
-		));
+		];
+
+		// Quick fix to pseudo decouple from mailing.
+		if ($this->_services->offsetExists('mailing.subscription.loader')){
+			$details['subscribed'] = $this->get('mailing.subscription.loader')->getByUser($user)->isSubscribed();
+		}
+
+		return $this->render('Message:Mothership:User::account:account', $details);
 	}
 
 	public function orderListing()

--- a/src/Controller/Account/Edit.php
+++ b/src/Controller/Account/Edit.php
@@ -72,18 +72,22 @@ class Edit extends Controller
 
 		if ($form->isValid() && $data = $form->getFilteredData()) {
 			$user = $this->get('user.current');
-			$subscriptionEdit = $this->get('mailing.subscription.edit');
 
 			$user->title 	= $data['title'];
 			$user->forename = $data['forename'];
 			$user->surname 	= $data['surname'];
 			$user->email 	= $data['email'];
 
-			if (isset($data['email_updates']) && $data['email_updates']) {
-				$subscriptionEdit->subscribe($data['email']);
-			} else {
-				$subscriptionEdit->unsubscribe($data['email']);
+			if ($this->_services->offsetExists('mailing.subscription.edit')){
+				$subscriptionEdit = $this->get('mailing.subscription.edit');
+
+				if (isset($data['email_updates']) && $data['email_updates']) {
+					$subscriptionEdit->subscribe($data['email']);
+				} else {
+					$subscriptionEdit->unsubscribe($data['email']);
+				}
 			}
+
 
 			if($this->get('user.edit')->save($user)) {
 				$this->addFlash('success', $this->get('translator')->trans('ms.user.user.update.success'));
@@ -193,9 +197,11 @@ class Edit extends Controller
 		$form->add('email', 'email', $this->get('translator')->trans('ms.user.user.email'), array('data' => $user->email))
 			->val()->maxLength(255);
 
-		$form->add('email_updates', 'checkbox', $this->get('translator')->trans('ms.user.user.email-updates'), array(
-			'data' => $this->get('mailing.subscription.loader')->getByUser($user)->isSubscribed(),
-		))->val()->optional();
+		if ($this->_services->offsetExists('mailing.subscription.edit')) {
+			$form->add('email_updates', 'checkbox', $this->get('translator')->trans('ms.user.user.email-updates'), array(
+				'data' => $this->get('mailing.subscription.loader')->getByUser($user)->isSubscribed(),
+			))->val()->optional();
+		}
 
 		return $form;
 	}


### PR DESCRIPTION
## What and why
Mailing isn't released yet which makes the badness of user being coupled to it even worse. This stops the account section breaking if mailing isn't installed.

We should handle this better in the future but for now this should stop the skeleton theme from breaking.

## How to test
Just have a look round the account section. Also try the account edit form on sites without mailing and with mailing installed. You shouldn't get any Whoops errors.