### PR TITLE
Disable email migration

### DIFF
--- a/resources/migrations/_1383909255_UpdateEmailSubscription.php
+++ b/resources/migrations/_1383909255_UpdateEmailSubscription.php
@@ -2,25 +2,17 @@
 
 use Message\Cog\Migration\Adapter\MySQL\Migration;
 
+/**
+ * This class does nothing. It used to create the email subscription table but would fail if the Mailing module was not
+ * installed, which became a problem after open sourcing Mothership as that module was not released. It turns out that
+ * the migration was pointless anyway as the columns it added are created by the mailing module anyway, but removing
+ * this migration entirely would cause errors to appear when running the initial install.
+ */
 class _1383909255_UpdateEmailSubscription extends Migration
 {
 	public function up()
-	{
-		$this->run("
-			ALTER TABLE `email_subscription`
-			ADD `subscribed` tinyint(1) DEFAULT 1,
-			ADD `updated_at` int(11) unsigned DEFAULT NULL,
-			ADD `updated_by` int(11) unsigned DEFAULT NULL;
-		");
-	}
+	{}
 
 	public function down()
-	{
-		$this->run('
-			ALTER TABLE `email_subscription`
-			DROP `subscribed`,
-			DROP `updated_at`,
-			DROP `updated_by`;
-		');
-	}
+	{}
 }


### PR DESCRIPTION
This PR disables the useless migration that breaks when the unreleased Mailing module is not installed