### PR TITLE
Removed debug code from password reset

### DIFF
--- a/src/Controller/Account/Edit.php
+++ b/src/Controller/Account/Edit.php
@@ -152,7 +152,6 @@ class Edit extends Controller
 				$data['oldPassword'],
 				$this->get('user.loader')->getUserPassword($user)
 			)) {
-				de('wrong pwd');
 				$this->addFlash('error', $this->get('translator')->trans('ms.user.user.password.old-password-error'));
 			} elseif(strcmp($data['passwordRepeat'], $newPwd) !== 0) {
 				$this->addFlash('error', $this->get('translator')->trans('ms.user.user.password.match-error'));


### PR DESCRIPTION
This dump and exit was being called if a user got their password wrong while trying to reset it because some debug code had been left in. This removes it. As far as I can see the password resetting stuff seems to be working fine