### PR TITLE
Fix issue where users with no address are excluded from reports

### DIFF
--- a/src/Report/Filter/AddressTypeFilter.php
+++ b/src/Report/Filter/AddressTypeFilter.php
@@ -14,6 +14,7 @@ class AddressTypeFilter extends Choices implements ModifyQueryInterface
 	{
 		if (null === $choices) {
 			$choices = [
+				'all'      => 'All',
 				'delivery' => 'Delivery',
 				'billing'  => 'Billing',
 			];
@@ -41,14 +42,20 @@ class AddressTypeFilter extends Choices implements ModifyQueryInterface
 
 	public function apply(DB\QueryBuilder $queryBuilder)
 	{
-		$addressType = $this->getChoices() ?
-			$this->getChoices() :
-			'delivery';
+		$addressType = $this->getChoices();
 
 		if (is_array($addressType)) {
 			$addressType = array_shift($addressType);
 		}
 
-		$queryBuilder->where('address.type = ?s', [$addressType]);
+		$and = true;
+
+		if (!$addressType || $addressType === 'all') {
+			$queryBuilder->where('address.type IS NULL');
+			$addressType = 'delivery';
+			$and = false;
+		}
+
+		$queryBuilder->where('address.type = ?s', [$addressType], $and);
 	}
 }

--- a/src/Report/UserSummary.php
+++ b/src/Report/UserSummary.php
@@ -2,8 +2,6 @@
 
 namespace Message\Mothership\User\Report;
 
-use Message\Mothership\User\Report\Filter\AddressTypeFilter;
-use Message\Mothership\User\Report\Filter\CountryFilter;
 use Message\Mothership\User\Events;
 
 use Message\Cog\Location\CountryList;
@@ -130,6 +128,7 @@ class UserSummary extends AbstractReport implements FilterableInterface
 		;
 
 		$this->_dispatchEvent();
+
 		return $this->_queryBuilder->getQuery();
 	}
 


### PR DESCRIPTION
This PR adds an 'All' option to the address filter on the user report. If this is set, it shows all users regardless of whether they have an address set. It will also show the delivery address if they have one. This is the default behaviour if the filter is not set.